### PR TITLE
Fixes the header demo

### DIFF
--- a/src/app-header/app-header.html
+++ b/src/app-header/app-header.html
@@ -1,6 +1,8 @@
 <script type="text/stache" can-autorender>
-  <can-import from="vintage-shop/app-header/" />
-  <app-header></app-header>
+    <can-import from="vintage-shop/app-header/" />
+    <app-header></app-header>
 </script>
-<script src="/node_modules/steal/steal.js"
-        main="can/view/autorender/"></script>
+<script src="../../node_modules/steal/steal.js" main="can/view/autorender/"> 
+    import route from 'can/route/';
+</script>
+<link rel="stylesheet" href="../../styles.less" />


### PR DESCRIPTION
Learned that when using `{{routeUrl..}}` the script tag of the demo
need to have ` import route from 'can/route/‘;`.

cc. @tomgreever 